### PR TITLE
Add tile to quick settings

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -11,8 +11,8 @@ android {
         applicationId = "de.thomaskuenneth.benice"
         minSdk = 26
         targetSdk = 34
-        versionCode = 23
-        versionName = "1.1.7"
+        versionCode = 24
+        versionName = "1.1.8"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {
@@ -51,20 +51,20 @@ android {
 }
 
 dependencies {
-    implementation(platform("androidx.compose:compose-bom:2024.03.00"))
+    implementation(platform("androidx.compose:compose-bom:2024.04.01"))
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.ui:ui-graphics")
     implementation("androidx.compose.ui:ui-tooling-preview")
     implementation("androidx.compose.material3:material3")
     implementation("androidx.compose.material:material-icons-extended")
 
-    androidTestImplementation(platform("androidx.compose:compose-bom:2024.03.00"))
+    androidTestImplementation(platform("androidx.compose:compose-bom:2024.04.01"))
     androidTestImplementation("androidx.compose.ui:ui-test-junit4")
     debugImplementation("androidx.compose.ui:ui-test-manifest:")
 
-    implementation("androidx.core:core-ktx:1.12.0")
+    implementation("androidx.core:core-ktx:1.13.0")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.7.0")
-    implementation("androidx.activity:activity-compose:1.8.2")
+    implementation("androidx.activity:activity-compose:1.9.0")
     implementation("androidx.appcompat:appcompat:1.6.1")
     implementation("androidx.preference:preference-ktx:1.2.1")
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -41,6 +41,17 @@
             </intent-filter>
         </activity>
 
+        <service
+            android:name=".BeNiceTileService"
+            android:exported="true"
+            android:icon="@drawable/tile_service_icon"
+            android:label="@string/app_name"
+            android:permission="android.permission.BIND_QUICK_SETTINGS_TILE">
+            <intent-filter>
+                <action android:name="android.service.quicksettings.action.QS_TILE" />
+            </intent-filter>
+        </service>
+
     </application>
 
 </manifest>

--- a/app/src/main/java/de/thomaskuenneth/benice/AppChooser.kt
+++ b/app/src/main/java/de/thomaskuenneth/benice/AppChooser.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalHapticFeedback
@@ -63,6 +64,7 @@ fun AppChooser(
     onClick: (AppInfo) -> Unit,
     onLongClick: (AppInfo) -> Unit
 ) {
+    val iconColir = MaterialTheme.colorScheme.primary.toArgb()
     val context = LocalContext.current
     val onDone: (String) -> Unit = { url ->
         onClick(
@@ -74,7 +76,9 @@ fun AppChooser(
                     context.resources,
                     R.drawable.baseline_open_in_browser_24,
                     context.theme
-                )!!
+                )!!.also {
+                    it.setTint(iconColir)
+                }
             )
         )
     }

--- a/app/src/main/java/de/thomaskuenneth/benice/BeNiceTileService.kt
+++ b/app/src/main/java/de/thomaskuenneth/benice/BeNiceTileService.kt
@@ -1,0 +1,35 @@
+package de.thomaskuenneth.benice
+
+import android.app.PendingIntent
+import android.app.TaskStackBuilder
+import android.content.Intent
+import android.os.Build
+import android.service.quicksettings.Tile
+import android.service.quicksettings.TileService
+
+class BeNiceTileService : TileService() {
+
+    override fun onStartListening() {
+        super.onStartListening()
+        qsTile.run {
+            state = Tile.STATE_INACTIVE
+            this.updateTile()
+        }
+    }
+
+    override fun onClick() {
+        val resultIntent = Intent(this, AppChooserActivity::class.java)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            val resultPendingIntent: PendingIntent = TaskStackBuilder.create(this).run {
+                addNextIntentWithParentStack(resultIntent)
+                getPendingIntent(
+                    0,
+                    PendingIntent.FLAG_CANCEL_CURRENT or PendingIntent.FLAG_IMMUTABLE
+                )
+            }
+            startActivityAndCollapse(resultPendingIntent)
+        } else {
+            startActivityAndCollapse(resultIntent)
+        }
+    }
+}

--- a/app/src/main/res/drawable/tile_service_icon.xml
+++ b/app/src/main/res/drawable/tile_service_icon.xml
@@ -1,0 +1,16 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="6.35"
+    android:viewportHeight="6.35">
+  <path
+      android:pathData="M0.6606,0.2505h2.1449v5.8491h-2.1449z"
+      android:strokeWidth="0.500916"
+      android:fillColor="#00000000"
+      android:strokeColor="#ffffff"/>
+  <path
+      android:pathData="M3.5445,0.2505h2.1449v5.8491h-2.1449z"
+      android:strokeWidth="0.500916"
+      android:fillColor="#00000000"
+      android:strokeColor="#ffffff"/>
+</vector>

--- a/artwork/tile_service_icon.svg
+++ b/artwork/tile_service_icon.svg
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="24"
+   height="24"
+   viewBox="0 0 6.3499999 6.35"
+   version="1.1"
+   id="svg1"
+   inkscape:version="1.2 (dc2aeda, 2022-05-15)"
+   sodipodi:docname="tile_service_icon.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="true"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="px"
+     inkscape:zoom="16.025373"
+     inkscape:cx="3.2448543"
+     inkscape:cy="9.8593648"
+     inkscape:window-width="1390"
+     inkscape:window-height="964"
+     inkscape:window-x="234"
+     inkscape:window-y="25"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1"
+     showgrid="false" />
+  <defs
+     id="defs1" />
+  <g
+     inkscape:label="Ebene 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-50.52335,-58.833726)">
+    <rect
+       style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:0.500916;stroke-dasharray:none;stroke-opacity:1"
+       id="rect2-7-4-1-3"
+       width="2.1449177"
+       height="5.8490844"
+       x="51.183914"
+       y="59.084183" />
+    <rect
+       style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:0.500916;stroke-dasharray:none;stroke-opacity:1"
+       id="rect2-7-4-1-3-2"
+       width="2.1449177"
+       height="5.8490844"
+       x="54.067871"
+       y="59.084183" />
+  </g>
+</svg>

--- a/whatsnew.md
+++ b/whatsnew.md
@@ -1,3 +1,5 @@
 # What's new
 
-- Open any web address as one part of an app pair 
+- Added a Quick settings tile
+- Updated some tools and libraries
+- Minor bugfix: in the app chooser dialog, the color for the "open in browser" icon was always black


### PR DESCRIPTION
- Added a Quick settings tile
- Updated some tools and libraries
- Minor bugfix: in the app chooser dialog, the color for the "open in browser" icon was always black